### PR TITLE
docs: progressive CI adoption (warnings-first)

### DIFF
--- a/usage/CI_MINIMUM_ADOPTION.md
+++ b/usage/CI_MINIMUM_ADOPTION.md
@@ -31,6 +31,30 @@ Goal: stop architectural erosion early.
 
 Why third: it’s highly valuable, but language/tooling dependent.
 
+## Progressive Adoption (Keep Automation On, Avoid Noisy Failures)
+The goal is not “CI on at any cost”. The goal is **automation-aligned enforcement** that matches the current state of the project.
+
+If you wire automated CI jobs for gates you cannot satisfy yet (e.g., no tests exist, no boundary tooling exists), you will get constant failing checks and adoption will stall.
+
+Use staged maturity. Keep automation running, but keep early checks **informational / non-required** until prerequisites exist.
+
+### CI Maturity Levels (Suggested)
+- **L0: Doc hygiene (required)**  
+  - Checks: doc audit (`scripts/audit-docs.ps1 -FailOnWarning`)  
+  - Prerequisites: none (should be passable immediately)
+
+- **L1: Deterministic tests (required once tests exist)**  
+  - Checks: `ci/TEST_GATES.md` Gate T1 expectations  
+  - Prerequisites: at least one deterministic test suite exists and can run headlessly with timeouts
+
+- **L2: Boundary integrity (required once enforceable)**  
+  - Checks: `ci/ARCHITECTURE_GATES.md` Gate A1  
+  - Prerequisites: a tooling mechanism exists (static analysis / import allow/deny / dependency graph) and boundary terms are agreed
+
+- **L3: Risk signals (required when stable)**  
+  - Checks: coverage as a risk signal (T2), flakiness budget (T4), “ADR required” checks for boundary changes (A3)  
+  - Prerequisites: stable test execution history; agreed ownership for waivers and quarantine policies
+
 ## What to Do If You Have No CI Yet
 - Apply the same gates as PR checklist items (human review) until CI exists.
 - Do not weaken the rules; only change the enforcement mechanism.

--- a/usage/FIX_PLAN.md
+++ b/usage/FIX_PLAN.md
@@ -12,6 +12,7 @@ Context: Generated after a full re-run of `usage/AUDIT_PLAYBOOK.md`.
 1) Implement CI checks for gate principles
 - Why: the kit’s `ci/*_GATES.md` are intentionally principles; without wiring, enforcement falls back to human review (PR checklist discipline) until CI exists.
 - Minimum: one job each for docs/test/architecture/interface gates.
+  - Adoption guidance: implement progressively so CI stays high-signal (see `usage/CI_MINIMUM_ADOPTION.md`).
 
 2) Run `scripts/audit-docs.ps1 -FailOnWarning` in CI
 - Why: makes doc hygiene enforceable.

--- a/usage/FOR_EXISTING_PROJECTS.md
+++ b/usage/FOR_EXISTING_PROJECTS.md
@@ -11,6 +11,10 @@ _Provenance: This document originates from the AI_governance kit (https://github
 - Add `constitution/` and align terminology.
 - Add CI gates as warnings first (optional), then enforce.
 
+Practical rule for early adoption: keep CI automation aligned with current project maturity.
+- Prefer adding automated checks that can pass immediately (doc hygiene).
+- If a gate’s prerequisites do not exist yet (no tests, no boundary tooling), keep the check informational/non-required or enforce it via PR checklist review until the prerequisites are in place.
+
 ## Step 3: Pay Down the Biggest Risks
 Prioritize:
 - hidden IO and global state

--- a/usage/HOW_TO_IMPORT.md
+++ b/usage/HOW_TO_IMPORT.md
@@ -97,6 +97,8 @@ Copy is the right choice when you want a proven baseline and your main work is e
 
    - keep `ci/*_GATES.md` as principles, and implement them in your CI/tooling, or
    - keep them as human-review gates (temporary fallback) until CI exists.
+4. Adopt CI progressively to avoid noisy failures in early projects:
+   - start with `usage/CI_MINIMUM_ADOPTION.md` (L0 doc hygiene → L1 tests → L2 boundary integrity → L3 risk signals)
 
 ### Common Failure Modes (Copy)
 - Teams copy again later and create duplicates (“v2 folder”), causing drift.


### PR DESCRIPTION
## Summary
Adds staged, tool-agnostic guidance for progressive CI adoption so downstream repos avoid noisy failures when gates are wired before prerequisites exist.

## Why
A common early-adoption failure mode is wiring CI as if the project is already ready for strict gates (tests/boundary tooling/coverage policies). This produces constant failing checks and error spam, which undermines adoption. The kit already states gates are principles, but this makes the staged path explicit.

## What changed
- Added a "CI maturity levels" section (L0???L3) with prerequisites and warnings-first guidance
- Expanded existing-project adoption guidance with an explicit "avoid premature failing checks" rule
- Cross-linked progressive adoption guidance from import and fix-plan docs

## Verification
- `powershell -File scripts/audit-docs.ps1 -FailOnWarning`

## Documentation impact
Adoption docs now define staged CI maturity and prerequisites.

### DOC DELTA
- What behavior changed?
  - Documentation/adoption behavior: adds staged CI maturity guidance and clarifies warnings-first vs required checks.
- What rule / gate is affected?
  - CI adoption guidance for `ci/*_GATES.md` and doc/test/architecture gate rollout.
- What should downstream repos update?
  - Follow the staged rollout (L0 doc hygiene ??? L1 tests ??? L2 boundary integrity ??? L3 risk signals) and avoid adding failing CI jobs for unmet prerequisites.

Closes #3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces staged, tool-agnostic guidance for progressive CI rollout and cross-links it across adoption docs.
> 
> - Adds "CI Maturity Levels" (L0 doc hygiene → L1 deterministic tests → L2 boundary integrity → L3 risk signals) to `usage/CI_MINIMUM_ADOPTION.md` with prerequisites and warnings-first enforcement
> - Updates `usage/FOR_EXISTING_PROJECTS.md` with a practical rule to align CI automation to current project maturity and keep unmet gates informational
> - Extends `usage/HOW_TO_IMPORT.md` to recommend progressive CI adoption post-import and link to `usage/CI_MINIMUM_ADOPTION.md`
> - Enhances `usage/FIX_PLAN.md` to reference progressive adoption for high-signal CI and add optional doc link validation note
> 
> Focus remains documentation-only; no code or gate definitions changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86d8da35ecbf43f8ed1e3f89f4f08aea555e8067. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->