### PR TITLE
docs: notes/ parking-lot pattern and AI safeguards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ Desktop.ini
 
 # Logs
 *.log
+
+# Notes
+notes/local/**
+!notes/local/
+!notes/local/README.md

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This repository provides governance guidance and reusable documentation. It is n
 
 ### Research References (Advisory)
 - `research/PROFESSIONAL_STANDARDS_AND_REFERENCES.md`
+- `research/NOTES_PARKING_LOT_PRACTICES.md`
 
 ### RAG Notes (Advisory)
 - `architecture/rag/README.md`

--- a/constitution/AI_ENFORCEMENT.md
+++ b/constitution/AI_ENFORCEMENT.md
@@ -48,6 +48,11 @@ If needed, introduce a port.
 The AI MUST list all affected files and concepts.
 If scope expands, the AI MUST stop and ask for confirmation.
 
+## 4.1 Notes Protection (Hard Gate)
+If any affected file matches `notes/**`:
+- If the user did not explicitly ask to update notes: the AI MUST STOP and ask for explicit instruction.
+- If the user asked to update notes: the AI SHOULD follow the working-notes policy (append/link rather than rewrite where feasible).
+
 ## 5. Test Gate (“No Test, No Code”)
 No non-trivial change is accepted without:
 - tests

--- a/constitution/AI_RULES.md
+++ b/constitution/AI_RULES.md
@@ -102,6 +102,16 @@ This section is a **style-agnostic profile**: it describes the constraints that 
   - a clear policy: committed artifact vs build output
 - Generated documentation MUST NOT be edited manually without updating its source.
 
+### 5.3 Working Notes / Parking-Lot Notes (Non-Canonical)
+Some repositories include working notes intended to prevent context-switching (e.g., `notes/`).
+
+- `notes/**` MUST be treated as **non-canonical working notes** by default.
+- The AI MUST NOT edit files under `notes/**` unless explicitly instructed.
+- If explicitly instructed to update a note, the AI SHOULD prefer:
+  - appending new entries instead of rewriting existing text, and/or
+  - adding links to the Issue/ADR/PR where the item was resolved.
+- The AI MUST NOT refactor, reformat, or “clean up” notes as part of unrelated tasks.
+
 ## 6. Mandatory AI Behavior (When Acting As a Coding Assistant)
 - Before making changes, the AI MUST identify which layer the change belongs to.
 - If a rule would be violated, the AI MUST stop and propose a compliant alternative.

--- a/notes/README.md
+++ b/notes/README.md
@@ -1,0 +1,20 @@
+# Notes (Working Notes / Parking-Lot)
+
+This folder provides a low-friction place to capture project notes without derailing active work.
+
+**Important**: notes are not canonical documentation. Canonical rules and guidance live in `constitution/`, `ci/`, `usage/`, and ADRs under `adr/`.
+
+## Structure
+- `notes/committed/` — shared notes that are committed to the repo (reviewable).
+- `notes/local/` — personal notes that are intentionally not committed (ignored by `.gitignore`).
+
+## Guidelines
+- Prefer links over duplication: if something becomes a real decision, capture it as an ADR and link it here.
+- Keep committed notes **append-only and link-first** (avoid rewriting history; add links to the Issue/ADR/PR where resolved).
+
+## Related Documents
+- `constitution/AI_RULES.md`
+- `constitution/AI_ENFORCEMENT.md`
+- `usage/HOW_TO_IMPORT.md`
+- `usage/LOCAL_OVERLAY_AND_PRECEDENCE.md`
+

--- a/notes/committed/README.md
+++ b/notes/committed/README.md
@@ -1,0 +1,16 @@
+# Committed Notes (Shared)
+
+Use this folder for **shared** notes that are worth keeping in git history.
+
+## Policy (Recommended)
+- Treat these notes as **non-canonical** by default (working notes).
+- Prefer **append-only** updates:
+  - add a new entry rather than rewriting existing entries
+  - add links to the Issue/ADR/PR where the item was resolved
+- Keep the scope small and practical. If a note becomes authoritative, promote it to:
+  - an ADR (`adr/`), or
+  - a canonical usage/governance document under `constitution/` / `usage/`.
+
+## Suggested sub-structure (optional)
+- You may create per-person or per-topic files/folders, e.g.:\n  - `notes/committed/by-person/<name>.md`\n  - `notes/committed/by-topic/<topic>.md`\n\nKeep names stable and avoid excessive fragmentation.
+

--- a/notes/local/README.md
+++ b/notes/local/README.md
@@ -1,0 +1,12 @@
+# Local Notes (Personal / Not Committed)
+
+This folder is for **personal** scratch notes (parking-lot items, temporary lists, quick prototypes).
+
+It is intentionally excluded from version control:
+- root `.gitignore` ignores `notes/local/**`
+- this `README.md` is explicitly unignored so the folder exists in every clone/import
+
+## Usage
+- Keep your own files here (whatever helps you work quickly).
+- Do not expect these notes to be reviewed or shared via PR.
+

--- a/research/NOTES_PARKING_LOT_PRACTICES.md
+++ b/research/NOTES_PARKING_LOT_PRACTICES.md
@@ -1,0 +1,69 @@
+# Notes / Parking-Lot Practices (Advisory Research)
+
+_Provenance: This research note was added to the AI_governance kit (https://github.com/rhemzal/AI_governance)._
+
+## Purpose
+Summarize established practices for handling “working notes” in software projects:
+- keep notes low-friction (avoid derailing active work)
+- prevent notes from becoming accidental sources of truth
+- support both personal and shared note-taking
+
+This document is **advisory**. Normative rules live in `constitution/`.
+
+## Key patterns observed
+
+### 1) Split notes into “shared vs personal”
+Common practice is to keep two classes of notes:
+- **Shared/committed**: relevant to the team and worth versioning.
+- **Personal/local**: scratchpad, temporary lists, prototypes — useful for the individual, but not worth PR noise.
+
+This maps well to a two-tier structure:
+- `notes/committed/` (tracked)
+- `notes/local/` (untracked)
+
+### 2) Keep local notes close to the project, but excluded from version control
+A common approach is to keep a notes directory **inside** the project (so it’s always at hand), but exclude it from version control via ignore rules (global ignore or local excludes).
+
+Source: “Project notes” recommends a globally-ignored `.note/` directory kept inside the project tree for convenience.
+- `https://localheinz.com/articles/2019/10/25/project-notes/`
+
+### 3) Use Git ignore mechanisms intentionally (shared vs local-only)
+Git supports multiple scopes for ignore rules:
+- **Repo-wide shared ignore** via committed `.gitignore` (applies to all clones).
+- **Local-only ignore** via `.git/info/exclude` (not committed).
+- **Global ignore** (applies to all repos on the machine).
+
+Source: GitHub Docs “Ignoring files” (sections on `.gitignore`, global ignores, and `.git/info/exclude`).
+- `https://docs.github.com/articles/ignoring-files`
+
+### 4) Separate “working notes” from canonical decision records
+Teams commonly distinguish:
+- **RFCs**: speculative proposals for discussion (multiple options).
+- **ADRs**: records of decisions that reflect the current implementation.
+
+Working notes are neither RFCs nor ADRs; they should not silently become architectural authority.
+
+Sources:
+- `https://docs.wellcomecollection.org/architecture-decision-records-adr`
+- `https://candost.blog/adrs-rfcs-differences-when-which/`
+
+### 5) Isolate exploratory work from review-ready artifacts
+While not “notes” directly, the scratchpad-branch workflow illustrates a consistent principle:
+keep exploratory history separate, then produce a clean, reviewable artifact.
+
+Source: Scratchpad branches workflow.
+- `https://julien.ponge.org/posts/a-workflow-for-experiments-in-git-scratchpad-branches/`
+
+## Recommendations for this governance kit
+To keep “parking-lot notes” usable in AI-heavy workflows:
+- Provide both `notes/committed/` and `notes/local/`.
+- Prevent accidental commits of personal notes via ignore rules.
+- Treat `notes/**` as **non-canonical** by default (working notes), and avoid rewriting them during unrelated tasks.
+- For committed notes, prefer **append-only and link-first**: add a new line + link to the Issue/ADR/PR where something was resolved.
+
+## Related Documents
+- `constitution/AI_RULES.md`
+- `constitution/AI_ENFORCEMENT.md`
+- `usage/LOCAL_OVERLAY_AND_PRECEDENCE.md`
+- `usage/HOW_TO_IMPORT.md`
+

--- a/usage/HOW_TO_IMPORT.md
+++ b/usage/HOW_TO_IMPORT.md
@@ -75,6 +75,7 @@ After importing, verify these within one PR:
 ## Option A: Copy (Simplest)
 Copy these folders into your repo:
 - `constitution/`
+- `notes/`
 - `interface/`
 - `ci/`
 - `adr/`
@@ -99,6 +100,9 @@ Copy is the right choice when you want a proven baseline and your main work is e
    - keep them as human-review gates (temporary fallback) until CI exists.
 4. Adopt CI progressively to avoid noisy failures in early projects:
    - start with `usage/CI_MINIMUM_ADOPTION.md` (L0 doc hygiene → L1 tests → L2 boundary integrity → L3 risk signals)
+5. Enable a low-friction parking-lot for work-in-progress notes:
+   - use `notes/committed/` for shared notes
+   - use `notes/local/` for personal notes (intentionally ignored by `.gitignore`)
 
 ### Common Failure Modes (Copy)
 - Teams copy again later and create duplicates (“v2 folder”), causing drift.

--- a/usage/HOW_TO_USE_WITH_VSCODE.md
+++ b/usage/HOW_TO_USE_WITH_VSCODE.md
@@ -77,6 +77,15 @@ Ask:
 For behavior changes, require:
 - `### DOC DELTA` (template lives in `usage/HOW_TO_USE_WITH_COPILOT.md`)
 
+### 6) Protect working notes from accidental edits (Optional)
+If your repo uses a `notes/` parking-lot, explicitly instruct the assistant not to “clean up” or rewrite it during unrelated tasks.
+
+Example prompt line you can add:
+- “Treat `notes/**` as non-canonical working notes. Do not edit them unless I explicitly ask. If asked, prefer append/link updates.”
+
+Tool-specific (Cursor) suggestion:
+- Create a local Cursor rule that enforces the same behavior for `notes/**` in your project. Keep it local/team-controlled; do not treat it as part of the imported kit baseline.
+
 ## Workflow Notes (Avoid Duplication)
 Team process guidance (parallel vs serial work, definition of done, Doc Delta discipline) is maintained in:
 - `usage/HOW_TO_USE_WITH_COPILOT.md`

--- a/usage/QUICKGUIDE.md
+++ b/usage/QUICKGUIDE.md
@@ -15,6 +15,7 @@ This is the fastest path to get value from this repository.
    - `constitution/`
    - `adr/`
    - `usage/`
+   - `notes/` (recommended: committed vs local parking-lot notes)
    - (optional) `ci/`, `interface/`, `architecture/`
 2. Link them from your repo’s main README (so developers find them).
 3. Decide how strict you want to be:


### PR DESCRIPTION
## Summary
Adds a two-tier notes/parking-lot pattern (committed vs local) and defines normative AI behavior to prevent assistants from rewriting working notes unless explicitly instructed.

## Why
In AI-heavy workflows, assistants can treat ad-hoc notes as canonical docs and rewrite them during unrelated tasks. Teams also need a low-friction place to capture parking-lot items without PR noise.

## What changed
- Added `notes/committed/` (tracked) and `notes/local/` (ignored) with README guidance
- Updated root `.gitignore` to ignore `notes/local/**` while keeping `notes/local/README.md` tracked
- Added an advisory research note with cited external sources
- Updated `constitution/AI_RULES.md` and `constitution/AI_ENFORCEMENT.md` to protect `notes/**` from unintended edits
- Updated import/quickstart docs to recommend copying `notes/`
- Added a docs-only, optional VS Code/Cursor mention (no config shipped)

## Verification
- `powershell -File scripts/audit-docs.ps1 -FailOnWarning`

## Documentation impact
Introduces the `notes/` pattern and clarifies its status as non-canonical working notes.

### DOC DELTA
- What behavior changed?
  - Documentation/governance behavior: introduces a two-tier notes model and formal AI constraints around editing notes.
- What rule / gate is affected?
  - Documentation rules (working notes) and enforcement expectations for affected files.
- What should downstream repos update?
  - Copy `notes/` when importing the kit; keep `notes/local/**` ignored; treat `notes/**` as do-not-edit unless explicitly requested.

Closes #5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes a low-friction notes pattern and codifies protections to prevent accidental AI edits to working notes.
> 
> - Adds `notes/committed/` and `notes/local/` with READMEs; root `.gitignore` ignores `notes/local/**` but tracks `notes/local/README.md`
> - Updates `constitution/AI_RULES.md` and `constitution/AI_ENFORCEMENT.md` to treat `notes/**` as non-canonical and require explicit instruction (append/link-first)
> - Refreshes docs to reference the new pattern: `README.md`, `usage/HOW_TO_IMPORT.md`, `usage/QUICKGUIDE.md`, and `usage/HOW_TO_USE_WITH_VSCODE.md` (optional assistant guidance)
> - Adds advisory research note `research/NOTES_PARKING_LOT_PRACTICES.md` with external references
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23cc152f97615721a887ee2886752af8d875e7ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->