### PR TITLE
docs: AI-assisted adoption assessment prompts

### DIFF
--- a/usage/HOW_TO_IMPORT.md
+++ b/usage/HOW_TO_IMPORT.md
@@ -47,6 +47,9 @@ Do not run with two sources of truth.
 
 Recommended: record the decision as an ADR using `adr/ADR_TEMPLATE.md` (title suggestion: “Governance Baseline: Imported Kit vs Local”).
 
+If you want an AI to assess what to adopt (and in what order), see:
+- `usage/QUICKGUIDE.md` (Recipe D/E: adoption assessment prompts)
+
 ## Governance Versioning (Recommended)
 To keep governance auditable over time, record which kit version you imported.
 

--- a/usage/QUICKGUIDE.md
+++ b/usage/QUICKGUIDE.md
@@ -46,6 +46,59 @@ Then require:
 Add:
 - “Include the `### DOC DELTA` block in your output (see `usage/HOW_TO_USE_WITH_COPILOT.md`).”
 
+### Recipe D — Adoption Assessment (Existing Repo; Kit Imported)
+Use this when the kit is already present in the repo and you want an AI to recommend what to adopt (and in what order) without blindly copying everything.
+
+Paste this prompt:
+
+```
+Load `constitution/AI_RULES.md`.
+This task is assessment-only: do not change code/docs; do not propose diffs unless I ask.
+
+Context:
+- This is an existing repository adopting the AI_governance kit.
+- The kit is already available in this repo (folders like `constitution/`, `usage/`, `adr/`).
+
+Assess the current repo state and recommend an adoption order:
+1) **Findability**: where are the governance docs, ADRs, CI definitions, and notes (`notes/`)?
+2) **Architecture boundaries**: what appears to be core vs integration boundary today? Where is boundary drift risk highest?
+3) **Tests**: what is the current test posture? Are tests deterministic/headless? Where are the biggest gaps?
+4) **Docs drift**: which docs likely drift from behavior? Are there duplicated sources of truth?
+5) **CI readiness**: which gates can be automated immediately (high-signal) vs which require prerequisites?
+
+Output:
+- A short assessment (bullets).
+- A staged adoption recommendation in order (L0 → L3), with prerequisites for each stage:
+  - L0: doc hygiene (fast, deterministic)
+  - L1: deterministic tests
+  - L2: boundary integrity
+  - L3: risk signals (coverage/flakiness budget/ADR-required checks)
+- What to defer (and why).
+- List any missing information you could not infer (max 3 questions).
+```
+
+### Recipe E — Adoption Assessment (Existing Repo; Kit Not Yet Imported / URL Reference)
+Use this when the kit is not yet imported and you only have a Git URL reference. The goal is to decide how to import first, then run Recipe D.
+
+Paste this prompt:
+
+```
+This task is assessment-only: do not change code/docs.
+
+Context:
+- This is an existing repository considering adoption of the AI_governance kit at: <PASTE_GIT_URL_HERE>
+- Assume the kit is not yet imported unless you see it in the repo.
+
+1) Recommend an import approach (Copy vs Submodule vs Fork) based on practical constraints (team workflow, desired update cadence, willingness to customize).
+2) Recommend the minimal set of folders to import first (focus on high-signal, low-friction value).
+3) After import, instruct me to run Recipe D to produce a staged adoption plan.
+
+Output:
+- Recommended import approach + why.
+- Minimal import set + why.
+- Next steps checklist (human-doable).
+```
+
 ## 3) When ADR-First is Mandatory
 Use ADR-first when you:
 - change architecture boundaries/dependency rules


### PR DESCRIPTION
## Summary
Adds tool-agnostic copy-paste prompts to help an AI assess an existing repo and recommend which parts of this governance kit to adopt (and in what order), including a pre-import variant that starts from a Git URL reference.

## Why
Existing projects need contextual adoption, not blind copying. The kit already describes import strategies, overlays, and progressive adoption; these prompt recipes operationalize that guidance for AI-heavy workflows.

## What changed
- Added Recipe D/E in `usage/QUICKGUIDE.md`:
  - existing repo assessment (kit imported)
  - pre-import assessment (kit referenced by URL)
- Added a cross-link from `usage/HOW_TO_IMPORT.md` to the prompt recipes

## Verification
- `powershell -File scripts/audit-docs.ps1 -FailOnWarning`

## Documentation impact
Adds new prompt recipes and cross-links.

### DOC DELTA
- What behavior changed?
  - Documentation behavior: new AI prompt recipes for adoption assessment.
- What rule / gate is affected?
  - Adoption workflow guidance (import + progressive enforcement).
- What should downstream repos update?
  - Use Recipe D/E when adopting the kit in an existing repo (imported vs URL reference).

Closes #7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds AI-assisted adoption assessment guidance and cross-links.
> 
> - Introduces Recipe D/E in `usage/QUICKGUIDE.md` with copy-paste prompts for assessing adoption order in existing repos (kit imported vs URL-only pre-import)
> - Adds a reference in `usage/HOW_TO_IMPORT.md` pointing to these recipes for AI-driven assessment
> - Documentation-only; no functional or CI changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5df06576f5f48c26c6006851c2159019b0c3fcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->