### PR TITLE
docs: simplify README with quick-use prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,77 @@
 # AI-Assisted Development Governance Kit
 
-This repository is a reusable, project-agnostic governance kit for **AI-assisted software development**.
+This repository is a reusable, project-agnostic governance kit for **AI-assisted software development**: rules, enforcement expectations, and adoption workflows that keep AI-driven changes reviewable and enforceable.
 
-It provides:
-- **Normative rules** (what must/must not happen)
-- **Enforcement mechanisms** (how rules are enforced, including CI/CD gates)
-- **Decision frameworks** (how to choose architecture and data models; not cargo-culted defaults)
-- **Advisory theory grounding** (curated RAG-style notes to reduce dependence on any specific LLM’s training)
+Normative sources live in `constitution/` and `ci/`. Advisory reasoning notes live in `architecture/rag/`.
 
-Normative sources live in `constitution/` and `ci/`; `architecture/rag/` is advisory.
+## Quick use (existing project)
+If you’re evaluating this kit for an existing repo, start with an assessment prompt before importing anything.
 
-## Why This Exists
+- For ready-to-use prompt recipes, see `usage/QUICKGUIDE.md` (Recipe D/E).
 
-Motto: Speed with oversight; every decision traceable.
+### Copy-paste prompt (URL reference → adoption recommendation)
 
-- Author: Richard Hemzal. Keep choices auditable and reduce drift.
-- Speed up work with AI-assisted programming without losing control.
-- Test whether the rules remain universal across contexts and teams.
-- Apply the same rules beyond programming (business, physics) for consistency.
-- Clarify the future direction of programming work; show colleagues that AI is a tool to master.
+```
+This task is assessment-only. Do not change code/docs.
 
-## What This Repo Is
-- A **governance constitution** for AI-assisted development.
-- A set of **portable documents** you can copy into other repositories.
-- A place to store **ADRs** (Architecture Decision Records) that keep decisions explicit and reviewable.
+Context:
+- I want to evaluate adopting the AI_governance kit: https://github.com/rhemzal/AI_governance
+- My repo may be new or already in progress.
 
-## What This Repo Is Not
-- Not a code template.
-- Not a framework-specific starter.
-- Not a tool configuration repository (no vendor lock-in).
+1) Summarize what this kit provides (rules, enforcement, workflows) and what it does NOT provide.
+2) Assess what parts are applicable to my repo right now and what to defer.
+3) Recommend a staged adoption order (L0 → L3):
+   - L0: doc hygiene + daily enforcement prompt
+   - L1: deterministic tests
+   - L2: boundary integrity
+   - L3: risk signals (coverage/flakiness budget/ADR-required checks)
+4) Recommend an import approach (Copy vs Submodule vs Fork) and the minimal set of folders to import first.
+
+Output:
+- A short assessment.
+- A recommended adoption order with prerequisites.
+- What to defer (and why).
+- Max 3 blocking questions (only if truly necessary).
+```
+
+## What changes after adoption (expected AI behavior)
+If you actually adopt the kit (import + follow the workflows), you should expect the assistant to:
+- consult repo sources of truth first (rules/docs/tests/ADRs) before asking basic questions
+- keep scope explicit and diffs small
+- escalate to “high-risk mode” (ADR-first + compliance reporting) for boundary/contract changes
+- treat CI adoption progressively (high-signal checks first, stricter gates when prerequisites exist)
+- keep documentation aligned with behavior (using `DOC DELTA` as PR evidence/metadata)
+- treat `notes/**` as non-canonical working notes (do not rewrite unless explicitly instructed)
+
+## Start here (top links)
+- Core rules: [constitution/AI_RULES.md](constitution/AI_RULES.md)
+- Daily AI work: [constitution/AI_ENFORCEMENT_DAILY.md](constitution/AI_ENFORCEMENT_DAILY.md)
+- High-risk changes: [constitution/AI_ENFORCEMENT.md](constitution/AI_ENFORCEMENT.md)
+- Import guidance: [usage/HOW_TO_IMPORT.md](usage/HOW_TO_IMPORT.md)
+- Quick recipes & prompts: [usage/QUICKGUIDE.md](usage/QUICKGUIDE.md)
+- Progressive CI adoption: [usage/CI_MINIMUM_ADOPTION.md](usage/CI_MINIMUM_ADOPTION.md)
+- Architecture decision framework: [architecture/ARCHITECTURE_DECISION_FRAMEWORK.md](architecture/ARCHITECTURE_DECISION_FRAMEWORK.md)
+- ADR template: [adr/ADR_TEMPLATE.md](adr/ADR_TEMPLATE.md)
+- Local overlays & precedence: [usage/LOCAL_OVERLAY_AND_PRECEDENCE.md](usage/LOCAL_OVERLAY_AND_PRECEDENCE.md)
+
+## Repository structure
+- `constitution/` — core rules and enforcement contracts
+- `ci/` — CI gate principles (implementation varies by stack)
+- `adr/` — ADR templates and accepted decisions for this kit
+- `usage/` — import and adoption workflows (including prompt recipes)
+- `notes/` — committed vs local parking-lot notes
+- `architecture/` and `architecture/rag/` — decision guidance and advisory theory notes
+
+## PR Habit: “Doc Delta”
+When a PR changes behavior, include the `### DOC DELTA` block from [usage/HOW_TO_USE_WITH_COPILOT.md](usage/HOW_TO_USE_WITH_COPILOT.md).
+
+`DOC DELTA` is PR evidence/metadata: reference the source of truth (code/tests/ADRs) and list which docs were updated/removed.
 
 ## Attribution / Traceability
 If you copy parts of this kit into another repository, preserve the “Provenance” banner at the top of imported documents so the origin remains traceable.
 
 ## Disclaimer
 This repository provides governance guidance and reusable documentation. It is not legal advice and does not guarantee compliance with any standard or regulation.
-
-## Repository Structure
-- `constitution/` — core rules and enforcement contracts
-- `interface/` — rules for UI/CLI/TUI/headless interfaces and interface-specific CI gates
-- `architecture/` — architecture decision framework + data modeling guidance
-- `architecture/rag/` — short, curated theory notes (advisory; not normative)
-- `ci/` — CI/CD gate definitions (principles and checks; implementation varies by stack)
-- `tooling/` — AI-driven tool optimization protocols (experiments, benchmarks)
-- `adr/` — ADR templates and accepted decisions for this governance kit
-- `usage/` — how to import and apply this kit in other repositories
-
-## Documents (Start Here)
-
-## Find What You Need (Fast Navigation)
-- Daily AI work: [constitution/AI_ENFORCEMENT_DAILY.md](constitution/AI_ENFORCEMENT_DAILY.md)
-- High-risk change (boundaries/contracts): [constitution/AI_ENFORCEMENT.md](constitution/AI_ENFORCEMENT.md)
-- Write a decision the “professional” way: [adr/ADR_TEMPLATE.md](adr/ADR_TEMPLATE.md)
-- ADR index (this kit): [adr/README.md](adr/README.md)
-- Pick or justify an architecture: [architecture/ARCHITECTURE_DECISION_FRAMEWORK.md](architecture/ARCHITECTURE_DECISION_FRAMEWORK.md)
-- Compare styles quickly: [architecture/ARCHITECTURE_STYLE_MATRIX.md](architecture/ARCHITECTURE_STYLE_MATRIX.md)
-- Validate trade-offs (theory prompts): [architecture/rag/QUALITY_ATTRIBUTES.md](architecture/rag/QUALITY_ATTRIBUTES.md)
-- Avoid common failures: [architecture/rag/README.md](architecture/rag/README.md) (incl. distributed monolith + schema evolution)
-- Keep terms unambiguous (LLM-safe vocabulary): [architecture/TERMINOLOGY_GLOSSARY.md](architecture/TERMINOLOGY_GLOSSARY.md)
-- Import into another repo (and keep precedence clear): [usage/LOCAL_OVERLAY_AND_PRECEDENCE.md](usage/LOCAL_OVERLAY_AND_PRECEDENCE.md)
-- Minimum viable CI adoption: [usage/CI_MINIMUM_ADOPTION.md](usage/CI_MINIMUM_ADOPTION.md)
-
-### Constitution (Normative)
-- `constitution/AI_RULES.md`
-- `constitution/AI_ENFORCEMENT.md`
-- `constitution/AI_ENFORCEMENT_DAILY.md`
-
-### Interface Layer (Integration Boundary / Adapters)
-- `interface/INTERFACE_RULES_PROPOSAL.md`
-- `interface/INTERFACE_CI_GATES.md`
-
-### Architecture Decision Guidance
-- `architecture/ARCHITECTURE_DECISION_FRAMEWORK.md`
-- `architecture/ARCHITECTURE_STYLE_MATRIX.md`
-- `architecture/DATA_MODELING_GUIDE.md`
-
-### Research References (Advisory)
-- `research/PROFESSIONAL_STANDARDS_AND_REFERENCES.md`
-- `research/NOTES_PARKING_LOT_PRACTICES.md`
-
-### RAG Notes (Advisory)
-- `architecture/rag/README.md`
-- `architecture/rag/INFORMATION_HIDING.md`
-- `architecture/rag/CONWAYS_LAW.md`
-- `architecture/rag/QUALITY_ATTRIBUTES.md`
-- `architecture/rag/HEXAGONAL_RATIONALE_AND_FAILURE_MODES.md`
-- `architecture/rag/STATE_VS_EVENT_MODEL.md`
-- `architecture/rag/MEASURED_PERFORMANCE.md`
-- `architecture/rag/DISTRIBUTED_MONOLITH.md`
-- `architecture/rag/SCHEMA_EVOLUTION_AND_VERSIONING.md`
-
-### CI Gates (Principles)
-- `ci/ARCHITECTURE_GATES.md`
-- `ci/TEST_GATES.md`
-- `ci/INTERFACE_GATES.md`
-- `ci/DOC_GATES.md`
-
-### Tooling Protocols (Advisory)
-- `tooling/AI_TOOL_OPTIMIZATION.md`
-- `tooling/COPILOT_OPTIMIZATION_PROTOCOL.md`
-- `tooling/BENCHMARK_SCENARIOS.md`
-
-### ADRs
-- `adr/ADR_TEMPLATE.md`
-- `adr/ADR_0001_Automation_First_Interfaces.md`
-- `adr/ADR_0002_Architecture_Is_Contextual.md`
-- `adr/ADR_0003_RAG_Is_Advisory_Not_Normative.md`
-- `adr/ADR_0004_Tooling_Is_Experimental.md`
-
-### Usage
-- `usage/QUICKGUIDE.md`
-- `usage/HOW_TO_USE_WITH_COPILOT.md`
-- `usage/HOW_TO_USE_WITH_VSCODE.md`
-- `usage/AUDIT_PLAYBOOK.md`
-- `usage/AUDIT_REPORT.md` and `usage/FIX_PLAN.md` (latest audit run outputs)
-- `usage/HOW_TO_IMPORT.md`
-- `usage/FOR_EXISTING_PROJECTS.md`
-
-## Quick Start (Import Into Another Repo)
-1. Copy the folders you need (recommended minimum: `constitution/`, `interface/`, `adr/`, `usage/`).
-2. Make the rules discoverable:
-   - Keep rule files in the repo root or a top-level folder.
-   - Use consistent filenames and terminology.
-3. Add CI checks that enforce the rules (see `ci/`).
-
-## PR Habit: “Doc Delta”
-When a PR changes behavior, include the `### DOC DELTA` block from `usage/HOW_TO_USE_WITH_COPILOT.md`.
-`DOC DELTA` is PR evidence/metadata: reference the source of truth (code/tests/ADRs) and list which docs were updated/removed. It can be filled by AI and reviewed like any other PR content.
-For architecture-impacting changes, ensure the ADR includes `## Documentation Impact` (see `adr/ADR_TEMPLATE.md`).
-
-## Governance Principles (High-Level)
-- Rules are **normative**: MUST/MUST NOT.
-- Tooling protocols are **advisory** and experimental.
-- Architecture decisions are **contextual** and must be recorded.
-- RAG notes are **advisory**, used to explain trade-offs and failure modes.
 
 ## License
 This repository is intended to be publishable and reusable.


### PR DESCRIPTION
## Summary
Makes the root README action-first: a copy-paste prompt to evaluate/adopt the kit, a conservative description of expected AI behavior changes after adoption, and a short set of top links.

## Why
Most users judge adoption value from the README. The previous README was a long catalog; this version makes "how to use" and the expected benefits visible immediately.

## What changed
- Added a quick-use adoption prompt (URL reference)
- Added a short "What changes after adoption" behavior section
- Reduced README navigation to a small set of top links (full navigation lives in `usage/QUICKGUIDE.md`)

## Verification
- `powershell -File scripts/audit-docs.ps1 -FailOnWarning`

## Documentation impact
README only.

### DOC DELTA
- What behavior changed?
  - README now provides an action-first adoption entry point and sets expectations for AI behavior.
- What rule / gate is affected?
  - None (doc-only change).
- What should downstream repos update?
  - N/A (this repo only).

Closes #9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refocuses README on quick adoption and essentials.**
> 
> - Adds a copy-paste assessment prompt (URL-based) to evaluate/import the kit
> - Introduces an “expected AI behavior after adoption” section
> - Condenses navigation into a short "Start here" links list; points deeper navigation to `usage/QUICKGUIDE.md`
> - Brief repository structure overview retained and clarified
> - Reiterates PR habit `DOC DELTA` for documentation alignment
> 
> *Scope: README-only; removes prior long-form catalogs and scattered navigation.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9ba6d8c565d64f63ca157349ecad931a5ea1276. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->