### PR TITLE
docs: add normative language policy

### DIFF
--- a/constitution/AI_ENFORCEMENT.md
+++ b/constitution/AI_ENFORCEMENT.md
@@ -53,6 +53,13 @@ If any affected file matches `notes/**`:
 - If the user did not explicitly ask to update notes: the AI MUST STOP and ask for explicit instruction.
 - If the user asked to update notes: the AI SHOULD follow the working-notes policy (append/link rather than rewrite where feasible).
 
+## 4.2 Language Guard (Hard Gate)
+If a change affects canonical documentation paths (e.g., `constitution/**`, `ci/**`, `usage/**`, `adr/**`, `architecture/**`, root `README.md`, `.github/**` templates):
+- the AI MUST produce English output by default.
+- if the user requests non-English output for a canonical document, the AI MUST:
+  - STOP and confirm the intent, and
+  - redirect the change into `translations/<lang>/...` as a subordinate translation (unless the repository has an explicit local overlay that overrides this policy).
+
 ## 5. Test Gate (“No Test, No Code”)
 No non-trivial change is accepted without:
 - tests

--- a/constitution/AI_RULES.md
+++ b/constitution/AI_RULES.md
@@ -112,6 +112,33 @@ Some repositories include working notes intended to prevent context-switching (e
   - adding links to the Issue/ADR/PR where the item was resolved.
 - The AI MUST NOT refactor, reformat, or “clean up” notes as part of unrelated tasks.
 
+### 5.4 Language Policy (English-First; Translations Optional)
+To keep collaboration and AI-assisted work consistent, this kit defines a strict language policy for shared, canonical artifacts.
+
+#### 5.4.1 Canonical documentation (MUST be English)
+These are canonical and MUST be written in English:
+- root `README.md`
+- `constitution/**`
+- `ci/**`
+- `usage/**`
+- `adr/**`
+- `architecture/**` (including `architecture/rag/**`)
+- `.github/**` templates (issues / PRs)
+
+#### 5.4.2 Code comments (SHOULD be English)
+- Long-lived, shared code comments (public contracts, invariants, tricky logic) SHOULD be written in English.
+- Domain terms MAY remain in the domain’s natural language, but SHOULD be defined once (ADR/glossary) and used consistently (ubiquitous language).
+
+#### 5.4.3 Notes
+- `notes/local/**` MAY be any language (personal, not committed).
+- `notes/committed/**` SHOULD be English unless a local overlay explicitly defines another shared language.
+
+#### 5.4.4 Translations (optional; MUST be subordinate)
+Non-English translations MAY exist, but only as explicitly subordinate artifacts:
+- Translations MUST live under `translations/<lang>/...`.
+- Each translated document MUST state the canonical English source it mirrors (path + commit/SHA or version tag when possible).
+- Translations MUST NOT override canonical rules. If a translation conflicts with English canonical docs, English wins.
+
 ## 6. Mandatory AI Behavior (When Acting As a Coding Assistant)
 - Before making changes, the AI MUST identify which layer the change belongs to.
 - If a rule would be violated, the AI MUST stop and propose a compliant alternative.

--- a/notes/README.md
+++ b/notes/README.md
@@ -12,6 +12,10 @@ This folder provides a low-friction place to capture project notes without derai
 - Prefer links over duplication: if something becomes a real decision, capture it as an ADR and link it here.
 - Keep committed notes **append-only and link-first** (avoid rewriting history; add links to the Issue/ADR/PR where resolved).
 
+## Language policy (recommended)
+- `notes/local/` can be written in any language (personal, not committed).
+- `notes/committed/` should be written in English by default (shared, reviewable), unless your local governance overlay defines another shared language.
+
 ## Related Documents
 - `constitution/AI_RULES.md`
 - `constitution/AI_ENFORCEMENT.md`

--- a/notes/committed/README.md
+++ b/notes/committed/README.md
@@ -4,6 +4,7 @@ Use this folder for **shared** notes that are worth keeping in git history.
 
 ## Policy (Recommended)
 - Treat these notes as **non-canonical** by default (working notes).
+- Language: these notes SHOULD be English by default (shared, reviewable) unless a local overlay defines another shared language.
 - Prefer **append-only** updates:
   - add a new entry rather than rewriting existing entries
   - add links to the Issue/ADR/PR where the item was resolved

--- a/notes/local/README.md
+++ b/notes/local/README.md
@@ -10,3 +10,6 @@ It is intentionally excluded from version control:
 - Keep your own files here (whatever helps you work quickly).
 - Do not expect these notes to be reviewed or shared via PR.
 
+## Language
+- Any language is acceptable here. This folder is intentionally personal and not committed.
+

--- a/usage/LOCAL_OVERLAY_AND_PRECEDENCE.md
+++ b/usage/LOCAL_OVERLAY_AND_PRECEDENCE.md
@@ -16,6 +16,19 @@ Use this precedence order (highest wins):
 2. This kit’s constitution and enforcement documents
 3. Everything else (notes, examples, non-normative guidance)
 
+## Language Policy & Translations (Recommended)
+This kit is English-first for canonical governance so AI and humans share a stable baseline.
+
+Downstream repos MAY add language exceptions via a local overlay (recommended), for example:
+- a different shared language for `notes/committed/**`
+- a policy for translations (where they live, who maintains them)
+
+Recommended pattern:
+- Keep canonical governance documents in English.
+- Allow translations only as explicitly subordinate artifacts under `translations/<lang>/...`.
+  - Each translation should point to the canonical English source (path + version/SHA when possible).
+  - Translations must not override canonical rules.
+
 Within the imported kit, treat these as highest priority:
 - `constitution/AI_RULES.md` (normative rules)
 - `constitution/AI_ENFORCEMENT.md` (how rules are enforced and what evidence is required)


### PR DESCRIPTION
## Summary
- Add an English-first normative language policy for canonical governance docs.
- Define translations as optional, explicitly subordinate artifacts under `translations/<lang>/...`.
- Clarify notes language expectations (`notes/local/**` any language; `notes/committed/**` prefer English unless overlay).

## DOC DELTA
- What behavior changed?
  - Canonical governance docs are explicitly English-only; non-English output must go to subordinate translations.
  - Notes language is explicitly split: local notes may be any language; committed notes default to English.
- What rule / gate is affected?
  - `constitution/AI_RULES.md` (Documentation Rules ??? Language Policy)
  - `constitution/AI_ENFORCEMENT.md` (Hard Gate ??? Language Guard)
- What should downstream repos update?
  - If you want non-English shared docs, add an explicit local overlay override.
  - If you use translations, place them under `translations/<lang>/...` and reference the canonical English source.
- Evidence note (source-of-truth references):
  - These changes are normative policy text only; enforcement is via human review / CI gates that adopt these rules.

## Test plan
- [ ] Review the new language policy sections for clarity and scope.
- [ ] Confirm no OS/tool-specific commands were introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Establishes a clear English-first baseline for canonical governance docs and formalizes how translations and notes should be handled.
> 
> - Adds `Language Guard` (hard gate) to `AI_ENFORCEMENT.md` requiring English for canonical paths and redirecting non-English output to `translations/<lang>/...`
> - Introduces `Language Policy` in `AI_RULES.md` covering: canonical docs (MUST be English), code comments (SHOULD be English), notes (`notes/local/**` any language; `notes/committed/**` prefer English), and subordinate translations with source references
> - Updates `notes/README.md`, `notes/committed/README.md`, and `notes/local/README.md` to reflect language expectations
> - Updates `usage/LOCAL_OVERLAY_AND_PRECEDENCE.md` with guidance for local overlays to define language exceptions and manage translations
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08d1ecc99748b091feee2847eeefa8722642d124. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->