### PR TITLE
Add local overlay template for low-risk execution continuity

### DIFF
--- a/governance/LOCAL_OVERLAY_TEMPLATE.md
+++ b/governance/LOCAL_OVERLAY_TEMPLATE.md
@@ -1,0 +1,72 @@
+# LOCAL GOVERNANCE OVERLAY (TEMPLATE)
+
+_This file is a template from the AI_governance kit. Copy it into your target repository as `governance/LOCAL_OVERLAY.md` and customize it. Keep a short provenance note (source repo + version/SHA) so audits can trace the baseline._
+
+## Purpose
+- Why this overlay exists (org policy, deployment constraints, tooling, risk posture).
+
+## Scope
+- What it applies to (modules, services, teams, repositories).
+
+## Precedence
+- This overlay overrides/adds to the imported kit.
+- Conflicts are resolved by: overlay wins.
+
+## Additions (Additive Rules)
+
+### LOW-RISK Execution Continuity (Do Not Stall)
+- If the AI has sufficient context to proceed safely, it MUST continue to execution (read/search/edit/run tests) rather than stopping after describing what it would do.
+- The AI SHOULD only pause to ask questions when the task is genuinely blocked (missing credentials, missing inputs, high-risk ambiguity).
+
+### LOW-RISK Scope Continuity
+- Adding a small helper, test, or doc update required by the same change is not considered scope expansion.
+- If scope truly expands into a new module/area, the AI must announce the expansion and update the touched-file list.
+
+### Compliance Output Compatibility
+- For low-risk work, a short compliance footer is sufficient (e.g., `## COMPLIANCE` + `Decision: PROCEED|STOP`).
+- For high-risk work, the full `## COMPLIANCE REPORT` requirements apply.
+
+### National-Language Notes Allowance
+- National language is allowed in local notes areas (e.g., `notes/local/**`).
+- Canonical governance documents remain English-first.
+
+## Overrides (If Any)
+Only use overrides when unavoidable.
+
+- Override:
+  - Imported rule reference (path + section)
+  - Replacement text
+  - Rationale
+  - Risk accepted / mitigation
+
+## Verification
+- What checks prove compliance (CI gates, tests, audits)
+
+## Change Control
+- Changes to this overlay require an ADR (recommended) when they affect boundaries/contracts or enforcement.
+
+Recommended ADR trigger examples:
+- you weaken or change enforcement evidence requirements
+- you change architectural boundary expectations
+- you introduce exceptions to non-interactive execution/time limits
+
+## User Prompt (Copy/Paste): Quick LOW vs HIGH Risk Check
+"Do a risk preflight before changes:
+- List exact files you will touch
+- Confirm whether any boundary contract/interface, adapter/integration, architecture decision, security behavior, CI/gates, or canonical governance docs are affected
+Return: `Risk: LOW|HIGH` + 1–2 sentence justification.
+If LOW: proceed to execution.
+If HIGH/unclear: STOP and ask for confirmation."
+
+## Common Mistakes to Avoid
+- Writing a second “rules doc” that rephrases the constitution.
+- Overriding silently (no rationale, no explicit replacement).
+- Mixing normative requirements into advisory notes.
+
+## Related Documents
+- `usage/HOW_TO_IMPORT.md`
+- `usage/LOCAL_OVERLAY_AND_PRECEDENCE.md`
+- `constitution/AI_RULES.md`
+- `constitution/AI_ENFORCEMENT.md`
+- `ci/ARCHITECTURE_GATES.md`
+- `ci/TEST_GATES.md`

--- a/usage/HOW_TO_IMPORT.md
+++ b/usage/HOW_TO_IMPORT.md
@@ -38,6 +38,9 @@ When you must add local rules, add them as **project-specific overlays** and cle
 See:
 - `usage/LOCAL_OVERLAY_AND_PRECEDENCE.md`
 
+This kit provides a ready-to-copy overlay template:
+- `governance/LOCAL_OVERLAY_TEMPLATE.md` (copy to `governance/LOCAL_OVERLAY.md` in the target repo and customize)
+
 ## If You Already Have Governance
 Decide which of these this kit will be in your repo:
 - **Upstream baseline**: this kit is the canonical source for rules/gates; your repo adds a local overlay.
@@ -75,6 +78,9 @@ After importing, verify these within one PR:
 - Architecture selection is recorded (ADR) and boundary terms are consistent (core/boundary contracts/integration boundaries).
 - No duplicate “rules docs” were created during import.
 
+Recommended (when adopting Copilot/AI agents):
+- Add a repo-specific overlay using `governance/LOCAL_OVERLAY_TEMPLATE.md` and include a low-risk execution continuity rule.
+
 ## Option A: Copy (Simplest)
 Copy these folders into your repo:
 - `constitution/`
@@ -84,6 +90,7 @@ Copy these folders into your repo:
 - `adr/`
 - `usage/`
 - `architecture/`
+- `governance/` (optional but recommended: overlay template)
 
 Then link them from your main README.
 

--- a/usage/HOW_TO_USE_WITH_COPILOT.md
+++ b/usage/HOW_TO_USE_WITH_COPILOT.md
@@ -20,6 +20,16 @@ Trigger “high-risk” mode when:
 - changing interface behavior (automation-first)
 - changing error model
 
+## Risk Preflight Prompt (Copy/Paste)
+Use this at the start of a task to force a consistent LOW vs HIGH risk classification before edits.
+
+"Do a risk preflight before changes:
+- List exact files you will touch
+- Confirm whether any boundary contract/interface, adapter/integration, architecture decision, security behavior, CI/gates, or canonical governance docs are affected
+Return: `Risk: LOW|HIGH` + 1–2 sentence justification.
+If LOW: proceed to execution.
+If HIGH/unclear: STOP and ask for confirmation."
+
 ## Expected Outputs From the AI
 - explicit scope
 - constraints honored

--- a/usage/LOCAL_OVERLAY_AND_PRECEDENCE.md
+++ b/usage/LOCAL_OVERLAY_AND_PRECEDENCE.md
@@ -51,12 +51,15 @@ If you cannot explain the conflict and risk, do not override: add an **Additions
 Recommended:
 - governance/LOCAL_OVERLAY.md (or docs/governance/LOCAL_OVERLAY.md) in the target repo.
 
+This kit also ships a ready-to-copy template:
+- `governance/LOCAL_OVERLAY_TEMPLATE.md` (copy it to `governance/LOCAL_OVERLAY.md` in the target repo and customize).
+
 Avoid:
 - editing imported kit files directly (unless you intentionally fork)
 - scattering extra rules across multiple team docs
 
 ## Overlay Template (Copy/Paste)
-Use this template in the target repo.
+Use this template in the target repo (or copy from `governance/LOCAL_OVERLAY_TEMPLATE.md`).
 
 # LOCAL GOVERNANCE OVERLAY
 
@@ -74,6 +77,35 @@ Use this template in the target repo.
 - Rule ID / short name:
   - What is required
   - Evidence expected in PR/CI
+
+### Suggested Additions (Low-Risk Workflow Defaults)
+These are recommended because they prevent common "stall after planning" failure modes in coding-agent workflows.
+
+- **LOW-RISK Execution Continuity (Do Not Stall)**
+  - If the AI has sufficient context to proceed safely, it MUST continue to execution (read/search/edit/run tests) rather than stopping after describing what it would do.
+  - The AI SHOULD only pause to ask questions when the task is genuinely blocked (missing credentials, missing inputs, high-risk ambiguity).
+
+- **LOW-RISK Scope Continuity**
+  - Adding a small helper, test, or doc update required by the same change is not considered scope expansion.
+  - If scope truly expands into a new module/area, the AI must announce the expansion and update the touched-file list.
+
+- **LOW-RISK Compliance Output Compatibility**
+  - For low-risk work, a short compliance footer is sufficient (e.g., `## COMPLIANCE` + `Decision: PROCEED|STOP`).
+  - For high-risk work, the full `## COMPLIANCE REPORT` requirements apply.
+
+- **National-Language Notes Allowance**
+  - National language is allowed in local notes areas (e.g., `notes/local/**`).
+  - Canonical governance documents remain English-first.
+
+### User Prompt (Copy/Paste): Quick LOW vs HIGH Risk Check
+Paste at the start of a task to force a consistent risk classification before edits:
+
+"Do a risk preflight before changes:
+- List exact files you will touch
+- Confirm whether any boundary contract/interface, adapter/integration, architecture decision, security behavior, CI/gates, or canonical governance docs are affected
+Return: `Risk: LOW|HIGH` + 1–2 sentence justification.
+If LOW: proceed to execution.
+If HIGH/unclear: STOP and ask for confirmation."
 
 ## Overrides (If Any)
 Only use overrides when unavoidable.


### PR DESCRIPTION
Refs #13

### Summary
Adds a ready-to-copy local overlay template and updates the import/usage docs so downstream repos can enable low-risk “continue to execution” behavior without weakening high-risk gates.

### Changes
- Adds `governance/LOCAL_OVERLAY_TEMPLATE.md` (copy to `governance/LOCAL_OVERLAY.md` in downstream repos).
- Updates `usage/LOCAL_OVERLAY_AND_PRECEDENCE.md` with recommended low-risk additions (execution continuity, scope continuity, compliance compatibility, national-language notes allowance) + a copy/paste risk-preflight prompt.
- Updates `usage/HOW_TO_IMPORT.md` to reference the template and include it in the recommended import set.
- Updates `usage/HOW_TO_USE_WITH_COPILOT.md` with the risk-preflight prompt.

### Notes
- High-risk changes still require full enforcement and `## COMPLIANCE REPORT` per `constitution/AI_ENFORCEMENT.md`.
- Low-risk work can use a short `## COMPLIANCE` footer (daily-style) to avoid format deadlocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that introduces no runtime behavior changes; main risk is downstream workflow/policy adoption/interpretation.
> 
> **Overview**
> Adds `governance/LOCAL_OVERLAY_TEMPLATE.md`, a ready-to-copy local overlay that includes recommended *low-risk* workflow defaults (execution continuity, scope continuity, lighter compliance footer, and national-language notes allowance) plus an explicit risk-preflight prompt.
> 
> Updates `usage/HOW_TO_IMPORT.md`, `usage/LOCAL_OVERLAY_AND_PRECEDENCE.md`, and `usage/HOW_TO_USE_WITH_COPILOT.md` to reference the template, recommend including it during imports, and standardize the copy/paste LOW vs HIGH risk classification prompt.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea54752ae81d7575b4295c817201b7236e8e0434. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->