### PR TITLE
LOCAL_OVERLAY: operator steering + HIGH risk semantics (refs #17)

### DIFF
--- a/governance/LOCAL_OVERLAY_TEMPLATE.md
+++ b/governance/LOCAL_OVERLAY_TEMPLATE.md
@@ -14,9 +14,39 @@ _This file is a template from the AI_governance kit. Copy it into your target re
 
 ## Additions (Additive Rules)
 
+### Risk Semantics (LOW vs HIGH)
+- In Git workflows, most internal edits are reversible. Treat changes as **HIGH risk** primarily when they have external side effects, non-trivial blast radius, or create complexity/review explosion.
+- HIGH risk is **not** triggered by the mere possibility of an incorrect internal edit.
+
+**HIGH risk (STOP and confirm before edits)** when work involves:
+- external services/integrations, registrations, credentials, billing/payment steps, or any data-handling/exfiltration risk
+- public contracts/interfaces/boundaries, cross-service protocols, schema/migrations, or security-sensitive behavior
+- canonical governance/gates (`constitution/`, `ci/`, `usage/`, `architecture/`, `adr/`, `interface/`)
+- large cross-cutting refactors spanning multiple modules/areas (complexity/review explosion)
+
+**LOW risk (proceed to execution)** when work stays within:
+- a single module/component area
+- no new dependencies
+- no public contract/interface changes
+- no external integrations or sensitive data handling
+- changes remain reviewable (small helper/test/doc updates required by the same change are allowed)
+
 ### LOW-RISK Execution Continuity (Do Not Stall)
 - If the AI has sufficient context to proceed safely, it MUST continue to execution (read/search/edit/run tests) rather than stopping after describing what it would do.
 - The AI SHOULD only pause to ask questions when the task is genuinely blocked (missing credentials, missing inputs, high-risk ambiguity).
+
+### Operator Steering (“do not stop” / “do not pause”)
+- If the operator expresses general intent like “do not stop” / “do not pause”, interpret it as: continue within the current objective if safe; only stop on hard gates or if risk is HIGH/unclear after read-only discovery.
+- This MUST NOT be interpreted as permission to bypass hard stops.
+- If a STOP happens anyway, the AI MUST respond with:
+  - the exact gate/reason (1–2 lines)
+  - a minimal “unblock menu” (2–3 concrete reply options)
+  - a one-line scope boundary update the operator can paste verbatim
+
+Example “unblock menu” options:
+- “Proceed, but keep scope limited to: {module/component}; no new deps; no public contract changes.”
+- “Expand scope to include: {new area/files}; still no new deps; confirm?”
+- “Confirm HIGH-risk change: {what}; accepted risk: {summary}; proceed.”
 
 ### LOW-RISK Scope Continuity
 - Adding a small helper, test, or doc update required by the same change is not considered scope expansion.


### PR DESCRIPTION
## Summary
Adds operator-steering guidance (“do not stop / do not pause”) and clarifies LOW vs HIGH risk semantics in the downstream overlay template.

Refs #17

## Why
Downstream repos can stall when HIGH risk is interpreted too broadly and operators can’t easily adjust scope boundaries mid-flight. In Git workflows, routine internal edits are usually reversible; HIGH risk should focus on external side effects, blast radius, and complexity/review explosion.

## What changed
- Update governance/LOCAL_OVERLAY_TEMPLATE.md:
  - Define HIGH vs LOW risk triggers with emphasis on external side effects / blast radius / complexity.
  - Add an “Operator Steering” section describing the required STOP response format (reason/gate + unblock menu + paste-ready scope boundary).

## Verification
Docs-only change.

## Documentation impact
Updates the shipped downstream overlay template; downstream repos should copy the new sections into their local overlay as needed.

### DOC DELTA
- What behavior changed?
  - Adds guidance for operator phrases like “do not stop / do not pause” and clarifies when to treat work as HIGH vs LOW risk.
- What rule / gate is affected?
  - Downstream overlay guidance only (template), not the core constitution/enforcement.
- What should downstream repos update?
  - Copy the updated sections from governance/LOCAL_OVERLAY_TEMPLATE.md into governance/LOCAL_OVERLAY.md.
- Evidence note: include source-of-truth references (code/tests/ADRs/docs). This block is PR evidence/metadata and can be generated by AI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only template changes with no runtime, security, or data-handling impact; risk is limited to how downstream teams interpret and apply the guidance.
> 
> **Overview**
> Updates the `governance/LOCAL_OVERLAY_TEMPLATE.md` to more explicitly define **LOW vs HIGH risk** work, emphasizing that HIGH risk is driven by external side effects/blast radius, contract/governance boundary changes, or large cross-cutting refactors.
> 
> Adds *operator-steering* guidance for phrases like “do not stop/do not pause”, including a required STOP response format (gate/reason + small unblock menu + paste-ready scope boundary) to reduce unnecessary stalls during low-risk execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bdea3f2d8d258c80400159b59d4ad072af92c23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->